### PR TITLE
feat: Add shadownet network support

### DIFF
--- a/services/index.js
+++ b/services/index.js
@@ -6,11 +6,13 @@ const nanoid = customAlphabet('1234567890abcdef', 16)
 const networkNameMap = {
   mainnet: "mainnet",
   ghostnet: "ghostnet",
+  shadownet: "shadownet",
 };
 
 const rpcNodes = {
   mainnet: "https://mainnet.api.tez.ie",
   ghostnet: "https://ghostnet.smartpy.io",
+  shadownet: "https://rpc.shadownet.teztnets.com",
 };
 
 const getTokenMetadata = async (contractAddress, network, tokenId) => {


### PR DESCRIPTION
## Summary
- Adds `shadownet` to the `networkNameMap` and `rpcNodes` in `services/index.js`
- This enables Lite DAO creation on the Shadownet testnet (replacing Ghostnet)
- Without this fix, TzKT API calls fail with `api.undefined.tzkt.io` because the network name is not mapped

## Test plan
- [x] Tested locally: Lite DAO creation on Shadownet succeeds
- [x] Verified TzKT API resolves correctly for `api.shadownet.tzkt.io`